### PR TITLE
Add `run_eio` function

### DIFF
--- a/lib/lwt_eio.ml
+++ b/lib/lwt_eio.ml
@@ -121,3 +121,13 @@ module Promise = struct
       );
     p
 end
+
+let run_eio fn =
+  let sw = get_loop_switch () in
+  let p, r = Lwt.wait () in
+  Fibre.fork ~sw (fun () ->
+      match fn () with
+      | x -> Lwt.wakeup r x; notify ()
+      | exception ex -> Lwt.wakeup_exn r ex; notify ()
+    );
+  p

--- a/lib/lwt_eio.mli
+++ b/lib/lwt_eio.mli
@@ -13,6 +13,12 @@ module Promise : sig
       This can only be used while the event loop created by {!with_event_loop} is still running. *)
 end
 
+val run_eio : (unit -> 'a) -> 'a Lwt.t 
+(** [run_eio fn] allows running Eio code from within a Lwt function.
+    It runs [fn ()] in a new Eio fibre and returns a promise for the result.
+    The new fibre is attached to the Lwt event loop's switch and will be
+    cancelled if the function passed to {!with_event_loop} returns. *)
+
 val notify : unit -> unit
 (** [notify ()] causes [Lwt_engine.iter] to return,
     indicating that the event loop should run the hooks and resume yielded threads.


### PR DESCRIPTION
This allows running Eio code from within a Lwt function. It attaches it to the event loop fibre rather than requiring a switch, as it's intended that the caller will immediately wait for the resulting Lwt promise to resolve. Lwt threads do not use structured concurrency anyway (e.g. they can call `Lwt.async` at any time).