### PR TITLE
Add Lwt_eio.t token to ensure library is initialised

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The first step is to replace `Lwt_main.run`, and check that the program still wo
 # open Eio.Std;;
 
 # Eio_main.run @@ fun env ->
-  Lwt_eio.with_event_loop ~clock:env#clock @@ fun () ->
+  Lwt_eio.with_event_loop ~clock:env#clock @@ fun _ ->
   Lwt_eio.Promise.await_lwt begin
     let input = Lwt_io.(of_bytes ~mode:input)
       (Lwt_bytes.of_bytes (Bytes.of_string "b\na\nd\nc\n")) in
@@ -192,7 +192,7 @@ We can now test it using an Eio flow:
 val sort : #Eio.Flow.source -> unit Lwt.t = <fun>
 
 # Eio_main.run @@ fun env ->
-  Lwt_eio.with_event_loop ~clock:env#clock @@ fun () ->
+  Lwt_eio.with_event_loop ~clock:env#clock @@ fun _ ->
   Lwt_eio.Promise.await_lwt begin
     sort (Eio.Flow.string_source "b\na\nd\nc\n")
   end;;
@@ -241,7 +241,7 @@ We can therefore now call it directly from Eio:
 
 ```ocaml
 # Eio_main.run @@ fun env ->
-  Lwt_eio.with_event_loop ~clock:env#clock @@ fun () ->
+  Lwt_eio.with_event_loop ~clock:env#clock @@ fun _ ->
   sort
     ~src:(Eio.Flow.string_source "b\na\nd\nc\n")
     ~dst:env#stdout;;
@@ -291,3 +291,6 @@ Key points:
   - External resources (such as `stdout`, the network and the filesystem) should be passed as inputs to Eio code.
 
   - Take a `Switch.t` argument if your function creates fibers or file handles that out-live the function.
+
+  - If you are writing a library that requires `Lwt_eio`, consider having its main function (if any)
+    take a value of type `Lwt_eio.Token.t`. This will remind users of the library to initialise Lwt_eio first.

--- a/lib/lwt_eio.ml
+++ b/lib/lwt_eio.ml
@@ -2,6 +2,12 @@ open Eio.Std
 
 exception Cancel
 
+module Token = struct
+  [@@@warning "-65"]
+  type t = ()
+  let v : t = ()
+end
+
 let ignore_cancel = function
   | Cancel -> ()
   | ex -> raise ex
@@ -93,7 +99,7 @@ let with_event_loop ~clock fn =
       | _ -> .
       | exception Exit -> ()
     );
-  Fun.protect fn
+  Fun.protect (fun () -> fn Token.v)
     ~finally:(fun () ->
         Lwt.wakeup r ();
         notify ()

--- a/lib/lwt_eio.mli
+++ b/lib/lwt_eio.mli
@@ -1,5 +1,18 @@
-val with_event_loop : clock:#Eio.Time.clock -> (unit -> 'a) -> 'a
-(** [with_event_loop ~clock fn] starts an Lwt event loop running and then executes [fn ()].
+module Token : sig
+  [@@@warning "-65"]
+  type t = private ()
+  (** A token indicating that Lwt_eio was started.
+
+      If a library needs Lwt_eio to be running, it can request this token to remind the application
+      to initialise it. This is most useful if a library has a main entry point, or some configuration
+      value that has to be constructed before the library is used.
+
+      This type should be treated as abstract, but it is defined as [private ()] to avoid breaking
+      existing code. *)
+end
+
+val with_event_loop : clock:#Eio.Time.clock -> (Token.t -> 'a) -> 'a
+(** [with_event_loop ~clock fn] starts an Lwt event loop running and then executes [fn t].
     When that finishes, the event loop is stopped. *)
 
 module Promise : sig


### PR DESCRIPTION
`with_event_loop` now passes a `Lwt_eio.t` token to its callback.

If a library needs Lwt_eio to be running, it can request this token to remind the application to initialise it. This is most useful if a library has a main entry point, or some configuration value that has to be constructed before the library is used.

This type should be treated as abstract, but it is defined here as `private ()` to avoid breaking existing code.

Not sure if this will prove useful or not, but seems worth a try.